### PR TITLE
Harden image

### DIFF
--- a/.github/workflows/rolling-release.yaml
+++ b/.github/workflows/rolling-release.yaml
@@ -1,10 +1,7 @@
 name: Rolling Release
 on:
-  push:
-    branches:
-      - main
   schedule:
-    - cron: "0 1 * * 0"
+    - cron: "0 0 1 * *"
   workflow_dispatch:
 jobs:
   release:
@@ -30,8 +27,6 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
-          build-args: |
-            PEPPER_GIT_URL=https://github.com/SLIB53/pepper-fish-theme.git
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/slib53/bloobox

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora
+FROM fedora:37
 
 # Install Base Setup
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
 FROM fedora
 
-ARG PEPPER_GIT_URL
-
 # Install Base Setup
 
 # DIRTY: for rolling release, instruction defines an inconsistent layer
 RUN dnf upgrade --assumeyes \
-    && dnf install --assumeyes bat fish git procps tree unzip which zip \
+    && dnf install --assumeyes fish git-core unzip \
     && dnf clean all -y
 
 ## Configure Fish Shell
@@ -15,9 +13,14 @@ RUN mkdir -p /root/.config/fish/functions \
     && echo 'set fish_greeting' >/root/.config/fish/functions/fish_greeting.fish
 
 # DIRTY: for rolling release, instruction defines an inconsistent layer
-RUN PEPPER_WORKING_COPY_DIR=/tmp/workspace/github.com/slib53/pepper-fish-theme \
+RUN PEPPER_GIT_URL=https://github.com/SLIB53/pepper-fish-theme.git \
+    && PEPPER_WORKING_COPY_DIR=/tmp/workspace/github.com/slib53/pepper-fish-theme \
     && git clone --branch release-bloobox --single-branch ${PEPPER_GIT_URL} ${PEPPER_WORKING_COPY_DIR} \
     && cd ${PEPPER_WORKING_COPY_DIR} && fish scripts/apply_theme.fish
+
+## Import Scripts
+
+COPY scripts /root/scripts
 
 # Clean Up
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,9 @@ needs!
 
 ## Installed Tools
 
-- bat
 - fish
 - git
-- procps
-- tree
 - unzip
-- which
-- zip
 
 ## Usage
 
@@ -35,7 +30,7 @@ Run a temporary bloobox container for your current directory:
 docker run --rm -it -v $PWD:/mnt/h$PWD -w /mnt/h$PWD ghcr.io/slib53/bloobox
 ```
 
-### Build
+### Build & Run
 
 **Please note** that the [Dockerfile](Dockerfile) might need to be built with
 the `--no-cache` flag so that the latest dependencies are included in the build.
@@ -43,9 +38,7 @@ the `--no-cache` flag so that the latest dependencies are included in the build.
 #### Building from GitHub
 
 ```sh
-docker build --no-cache \
-    --build-arg PEPPER_GIT_URL=https://github.com/SLIB53/pepper-fish-theme.git \
-    --rm -t github.com/slib53/bloobox https://github.com/SLIB53/bloobox.git#main
+docker build --no-cache --rm -t github.com/slib53/bloobox https://github.com/SLIB53/bloobox.git#main
 ```
 
 Then, to run:
@@ -59,13 +52,37 @@ docker run --rm -it github.com/slib53/bloobox
 ```sh
 git clone https://github.com/SLIB53/bloobox.git
 cd bloobox
-docker build --no-cache \
-    --build-arg PEPPER_GIT_URL=https://github.com/SLIB53/pepper-fish-theme.git \
-    --rm -t local/bloobox .
+docker build --no-cache --rm -t local/bloobox .
 ```
 
 Then, to run:
 
 ```sh
 docker run --rm -it local/bloobox
+```
+
+### Installers
+
+#### Terraform
+
+To install Terraform, run the following command:
+
+```sh
+fish ~/scripts/install_terraform.fish
+```
+
+#### AWS CLI
+
+To install the AWS CLI, run the following command:
+
+```sh
+fish ~/scripts/install_aws_cli.fish
+```
+
+#### Extras
+
+To install extras, run the following command:
+
+```sh
+fish ~/scripts/install_extras.fish
 ```

--- a/README.md
+++ b/README.md
@@ -49,9 +49,16 @@ docker run --rm -it github.com/slib53/bloobox
 
 #### Building locally
 
+Clone the repository:
+
 ```sh
 git clone https://github.com/SLIB53/bloobox.git
 cd bloobox
+```
+
+Now build the image:
+
+```sh
 docker build --no-cache --rm -t local/bloobox .
 ```
 
@@ -76,7 +83,7 @@ fish ~/scripts/install_terraform.fish
 To install the AWS CLI, run the following command:
 
 ```sh
-fish ~/scripts/install_aws_cli.fish
+fish ~/scripts/install_awscli.fish
 ```
 
 #### Extras

--- a/scripts/install_awscli.fish
+++ b/scripts/install_awscli.fish
@@ -1,0 +1,29 @@
+mkdir -p /tmp/install-awscli
+
+cd /tmp/install-awscli
+
+begin
+    echo "Resolving version..."
+
+    set --local arch $(uname -m)
+
+    if [ "$arch" = aarch64 ]
+        set --global APP_DOWNLOAD_URL https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip
+    else if [ "$arch" = x86_64 ]
+        set --global APP_DOWNLOAD_URL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip
+    else
+        echo "Unsupported architecture: $arch"
+        exit 1
+    end
+end
+
+begin
+    echo "Downloading from $APP_DOWNLOAD_URL..."
+
+    curl $APP_DOWNLOAD_URL \
+        -o awscli.zip
+
+    unzip awscli.zip
+
+    ./aws/install
+end

--- a/scripts/install_extras.fish
+++ b/scripts/install_extras.fish
@@ -1,0 +1,1 @@
+dnf install bat gh neovim procps tree which zip

--- a/scripts/install_terraform.fish
+++ b/scripts/install_terraform.fish
@@ -1,0 +1,29 @@
+mkdir -p /tmp/install-terraform
+
+cd /tmp/install-terraform
+
+begin
+    echo "Resolving version..."
+
+    set --local arch $(uname -m)
+
+    if [ "$arch" = aarch64 ]
+        set --global APP_DOWNLOAD_URL https://releases.hashicorp.com/terraform/1.3.5/terraform_1.3.5_linux_arm64.zip
+    else if [ "$arch" = x86_64 ]
+        set --global APP_DOWNLOAD_URL https://releases.hashicorp.com/terraform/1.3.5/terraform_1.3.5_linux_amd64.zip
+    else
+        echo "Unsupported architecture: $arch"
+        exit 1
+    end
+end
+
+begin
+    echo "Downloading app from $APP_DOWNLOAD_URL..."
+
+    curl $APP_DOWNLOAD_URL \
+        -o terraform.zip
+
+    unzip terraform.zip
+
+    mv terraform /usr/local/bin
+end


### PR DESCRIPTION
This change removes the installation of packages from the Dockerfile and provides a suite of install scripts instead. In addition to the utilities previously provided by default, install scripts for AWS CLI and Terraform are included as well.

This also changes the base image from Fedora latest to a specific version (37, which is currently latest).

The public image will now be built monthly (or manually on a workflow dispatch).